### PR TITLE
Check if tags are defined...

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ module.exports = (options = {}, context) => ({
                 push_twit('twitter:creator', creator);
             }
             else if (default_twitter_creator) {
-                if(!default_twitter_creator.includes("@")) {
+                if(twitter_creator && !twitter_creator.includes("@")) {
                     creator = "@"+default_twitter_creator
                 }else{
                     creator = default_twitter_creator
@@ -208,7 +208,7 @@ module.exports = (options = {}, context) => ({
             }
 
             if (!is_duplicate_tw('twitter:site') && default_twitter_site) {
-                if (!default_twitter_site.includes("@")) {
+                if (twitter_site && !twitter_site.includes("@")) {
                     sit = "@" + default_twitter_site
                 } else {
                     sit = default_twitter_site


### PR DESCRIPTION
before looking for values within. This change avoids errors at runtime. This fix may need to be applied elsewhere as well, these are just the changes I needed to get the plugin to run.